### PR TITLE
fix: use configureAwait(false) to prevent deadlock in synchronization contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ TestResult.xml
 nunit-*.xml
 
 .env
+.idea
+.DS_Store

--- a/src/Infisical.Sdk.DeadlockTest/Infisical.Sdk.DeadlockTest.csproj
+++ b/src/Infisical.Sdk.DeadlockTest/Infisical.Sdk.DeadlockTest.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Infisical.Sdk/Infisical.Sdk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Infisical.Sdk.DeadlockTest/Program.cs
+++ b/src/Infisical.Sdk.DeadlockTest/Program.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Infisical.Sdk;
+using Infisical.Sdk.Model;
+
+namespace Infisical.Sdk.DeadlockTest
+{
+    // Custom SynchronizationContext that simulates WinForms behavior
+    public class WinFormsSynchronizationContext : SynchronizationContext
+    {
+        private readonly Thread _mainThread;
+        private readonly Queue<(SendOrPostCallback, object?)> _queue = new();
+        private readonly object _lock = new();
+        private volatile bool _running = true;
+
+        public WinFormsSynchronizationContext()
+        {
+            _mainThread = Thread.CurrentThread;
+        }
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            lock (_lock)
+            {
+                _queue.Enqueue((d, state));
+                Monitor.Pulse(_lock);
+            }
+        }
+
+        public override void Send(SendOrPostCallback d, object? state)
+        {
+            if (Thread.CurrentThread == _mainThread)
+            {
+                d(state);
+            }
+            else
+            {
+                var executed = false;
+                var exception = (Exception?)null;
+
+                Post(_ =>
+                {
+                    try
+                    {
+                        d(state);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ex;
+                    }
+                    finally
+                    {
+                        lock (_lock)
+                        {
+                            executed = true;
+                            Monitor.Pulse(_lock);
+                        }
+                    }
+                }, null);
+
+                lock (_lock)
+                {
+                    while (!executed)
+                        Monitor.Wait(_lock);
+                }
+
+                if (exception != null)
+                    throw exception;
+            }
+        }
+
+        public void ProcessMessages()
+        {
+            while (_running)
+            {
+                (SendOrPostCallback, object?) item;
+
+                lock (_lock)
+                {
+                    while (_queue.Count == 0 && _running)
+                        Monitor.Wait(_lock, 100);
+
+                    if (!_running) break;
+                    if (_queue.Count == 0) continue;
+
+                    item = _queue.Dequeue();
+                }
+
+                try
+                {
+                    item.Item1(item.Item2);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Exception in message loop: {ex.Message}");
+                }
+            }
+        }
+
+        public void Stop()
+        {
+            lock (_lock)
+            {
+                _running = false;
+                Monitor.PulseAll(_lock);
+            }
+        }
+    }
+
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            Console.WriteLine("=== Infisical SDK Deadlock Demonstration ===\n");
+
+            // Test 1: Normal console app behavior (no deadlock)
+            Console.WriteLine("1. Testing in normal console context...");
+            TestNormalConsole();
+
+            Console.WriteLine("\n" + new string('=', 50) + "\n");
+
+            // Test 2: Simulated WinForms context (deadlock)
+            Console.WriteLine("2. Testing in simulated WinForms context...");
+            TestSimulatedWinForms();
+
+            Console.WriteLine("\n" + new string('=', 50) + "\n");
+
+            // Test 3: Proper async/await solution
+            Console.WriteLine("3. Testing proper async/await solution...");
+            TestAsyncAwaitSolution();
+
+            Console.WriteLine("\n" + new string('=', 50) + "\n");
+
+            // Test 4: Task.Run workaround
+            Console.WriteLine("4. Testing Task.Run workaround...");
+            TestTaskRunWorkaround();
+        }
+
+        private static void TestNormalConsole()
+        {
+            try
+            {
+                var settings = new InfisicalSdkSettingsBuilder()
+                    .WithHostUri("https://app.infisical.com")
+                    .Build();
+
+                var client = new InfisicalClient(settings);
+
+                Console.WriteLine("Using .Result in console app (works fine)...");
+                var task = client.Auth().UniversalAuth().LoginAsync("fake-id", "fake-secret");
+
+                // This works fine in console apps
+                try
+                {
+                    var result = task.Result;
+                    Console.WriteLine("✅ No deadlock occurred (but auth failed as expected)");
+                }
+                catch (AggregateException ex)
+                {
+                    Console.WriteLine($"✅ No deadlock - got expected auth error: {ex.InnerException?.Message}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"❌ Unexpected error: {ex.Message}");
+            }
+        }
+
+        private static void TestSimulatedWinForms()
+        {
+            var winformsContext = new WinFormsSynchronizationContext();
+            var deadlockDetected = false;
+            var completed = false;
+            Exception? caughtException = null;
+
+            // This will run the actual test on the UI thread simulation
+            var testCompletionSource = new TaskCompletionSource<bool>();
+
+            // Post the deadlock test to run on the "UI thread"
+            winformsContext.Post(_ =>
+            {
+                try
+                {
+                    // Set this thread's synchronization context
+                    SynchronizationContext.SetSynchronizationContext(winformsContext);
+
+                    var settings = new InfisicalSdkSettingsBuilder()
+                        .WithHostUri("https://app.infisical.com")
+                        .Build();
+
+                    var client = new InfisicalClient(settings);
+
+                    Console.WriteLine("Using .Result in WinForms-like context...");
+                    Console.WriteLine("⏳ This should demonstrate a deadlock scenario...");
+
+                    // This is the problematic pattern - calling .Result on the UI thread
+                    // where the continuation needs to return to the same thread
+                    var loginTask = client.Auth().UniversalAuth().LoginAsync("fake-id", "fake-secret");
+
+                    // This should cause a deadlock if the SDK doesn't use ConfigureAwait(false)
+                    try
+                    {
+                        var result = loginTask.Result;
+                        completed = true;
+                        Console.WriteLine("✅ Completed without deadlock (SDK properly uses ConfigureAwait(false))");
+                    }
+                    catch (AggregateException ex)
+                    {
+                        completed = true;
+                        Console.WriteLine($"✅ Completed with expected auth error: {ex.InnerException?.Message}");
+                        Console.WriteLine("   No deadlock occurred - SDK properly uses ConfigureAwait(false)");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    caughtException = ex;
+                    Console.WriteLine($"❌ Unexpected error: {ex.Message}");
+                }
+                finally
+                {
+                    testCompletionSource.SetResult(true);
+                }
+            }, null);
+
+            // Start the message pump and wait for the test to complete or timeout
+            var messagePumpTask = Task.Run(() => winformsContext.ProcessMessages());
+
+            // Wait for test completion or timeout (deadlock detection)
+            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(5));
+            var completedTask = Task.WhenAny(testCompletionSource.Task, timeoutTask);
+
+            if (completedTask.Result == timeoutTask)
+            {
+                deadlockDetected = true;
+                Console.WriteLine("❌ DEADLOCK DETECTED - Test didn't complete within 5 seconds");
+                Console.WriteLine("   This means the SDK is NOT using ConfigureAwait(false) properly");
+                Console.WriteLine("   In a real WinForms app, the UI would freeze indefinitely");
+            }
+
+            // Clean up
+            winformsContext.Stop();
+            messagePumpTask.Wait(TimeSpan.FromSeconds(1));
+
+            // Report final results
+            if (deadlockDetected)
+            {
+                Console.WriteLine("\n🎯 TEST RESULT: DEADLOCK DETECTED!");
+                Console.WriteLine("   ❌ The SDK needs ConfigureAwait(false) on all await calls");
+                Console.WriteLine("   ❌ Using .Result in WinForms/WPF will freeze the UI");
+            }
+            else if (completed)
+            {
+                Console.WriteLine("\n✅ TEST RESULT: NO DEADLOCK DETECTED!");
+                Console.WriteLine("   ✅ The SDK properly uses ConfigureAwait(false)");
+                Console.WriteLine("   ✅ Using .Result in WinForms/WPF should be safe");
+            }
+            else if (caughtException != null)
+            {
+                Console.WriteLine($"\n❌ TEST RESULT: Test failed with exception: {caughtException.Message}");
+            }
+        }
+
+        private static void TestAsyncAwaitSolution()
+        {
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var settings = new InfisicalSdkSettingsBuilder()
+                        .WithHostUri("https://app.infisical.com")
+                        .Build();
+
+                    var client = new InfisicalClient(settings);
+
+                    Console.WriteLine("Using proper async/await pattern...");
+
+                    try
+                    {
+                        var result = await client.Auth().UniversalAuth().LoginAsync("fake-id", "fake-secret");
+                        Console.WriteLine("✅ Async/await completed successfully");
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"✅ Async/await completed with expected error: {ex.Message}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"❌ Unexpected error: {ex.Message}");
+                }
+            }).Wait();
+        }
+
+        private static void TestTaskRunWorkaround()
+        {
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var settings = new InfisicalSdkSettingsBuilder()
+                        .WithHostUri("https://app.infisical.com")
+                        .Build();
+
+                    var client = new InfisicalClient(settings);
+
+                    Console.WriteLine("Using Task.Run workaround...");
+
+                    try
+                    {
+                        await Task.Run(async () =>
+                        {
+                            var result = await client.Auth().UniversalAuth().LoginAsync("fake-id", "fake-secret");
+                            return result;
+                        });
+                        Console.WriteLine("✅ Task.Run workaround completed successfully");
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"✅ Task.Run workaround completed with expected error: {ex.Message}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"❌ Unexpected error: {ex.Message}");
+                }
+            }).Wait();
+        }
+    }
+}

--- a/src/Infisical.Sdk/Api/ApiClient.cs
+++ b/src/Infisical.Sdk/Api/ApiClient.cs
@@ -78,7 +78,7 @@ namespace Infisical.Sdk.Api
 
       try
       {
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         if (!string.IsNullOrEmpty(content))
         {
           message += $" - {content}";
@@ -111,15 +111,15 @@ namespace Infisical.Sdk.Api
           request.Headers.Add("Authorization", $"Bearer {_accessToken}");
         }
 
-        var response = await _httpClient.SendAsync(request);
+        var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
-          var errorMessage = await FormatErrorMessageAsync(response);
+          var errorMessage = await FormatErrorMessageAsync(response).ConfigureAwait(false);
           throw new HttpRequestException(errorMessage);
         }
 
-        var responseContent = await response.Content.ReadAsStringAsync();
+        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
         if (string.IsNullOrEmpty(responseContent))
         {
@@ -170,16 +170,16 @@ namespace Infisical.Sdk.Api
           {
             request.Headers.Add("Authorization", $"Bearer {_accessToken}");
           }
-          return await _httpClient.SendAsync(request);
-        });
+          return await _httpClient.SendAsync(request).ConfigureAwait(false);
+        }).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
-          var errorMessage = await FormatErrorMessageAsync(response);
+          var errorMessage = await FormatErrorMessageAsync(response).ConfigureAwait(false);
           throw new HttpRequestException(errorMessage);
         }
 
-        var responseContent = await response.Content.ReadAsStringAsync();
+        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
         if (string.IsNullOrEmpty(responseContent))
         {
@@ -223,15 +223,15 @@ namespace Infisical.Sdk.Api
           request.Headers.Add("Authorization", $"Bearer {_accessToken}");
         }
 
-        var response = await _httpClient.SendAsync(request);
+        var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
-          var errorMessage = await FormatErrorMessageAsync(response);
+          var errorMessage = await FormatErrorMessageAsync(response).ConfigureAwait(false);
           throw new HttpRequestException(errorMessage);
         }
 
-        var responseContent = await response.Content.ReadAsStringAsync();
+        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
         if (string.IsNullOrEmpty(responseContent))
         {
@@ -275,15 +275,15 @@ namespace Infisical.Sdk.Api
           request.Headers.Add("Authorization", $"Bearer {_accessToken}");
         }
 
-        var response = await _httpClient.SendAsync(request);
+        var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
-          var errorMessage = await FormatErrorMessageAsync(response);
+          var errorMessage = await FormatErrorMessageAsync(response).ConfigureAwait(false);
           throw new HttpRequestException(errorMessage);
         }
 
-        var responseContent = await response.Content.ReadAsStringAsync();
+        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
         if (string.IsNullOrEmpty(responseContent))
         {

--- a/src/Infisical.Sdk/Client/AuthClient.cs
+++ b/src/Infisical.Sdk/Client/AuthClient.cs
@@ -19,7 +19,7 @@ public class UniversalAuth
     {
       var loginRequest = new UniversalAuthLoginRequest(clientId, clientSecret);
 
-      var response = await _apiClient.PostAsync<UniversalAuthLoginRequest, MachineIdentityCredential>("/api/v1/auth/universal-auth/login", loginRequest);
+      var response = await _apiClient.PostAsync<UniversalAuthLoginRequest, MachineIdentityCredential>("/api/v1/auth/universal-auth/login", loginRequest).ConfigureAwait(false);
       _setAccessTokenFunc(response.AccessToken);
       return response;
     }

--- a/src/Infisical.Sdk/Client/PkiClient.cs
+++ b/src/Infisical.Sdk/Client/PkiClient.cs
@@ -23,7 +23,7 @@ public class Subscribers
       var response = await _apiClient.GetAsync<CertificateBundle>(
         $"/api/v1/pki/subscribers/{options.SubscriberName}/latest-certificate-bundle",
         dict
-      );
+      ).ConfigureAwait(false);
 
       return response;
     }
@@ -39,7 +39,7 @@ public class Subscribers
     {
       options.Validate();
 
-      var response = await _apiClient.PostAsync<IssueCertificateOptions, SubscriberIssuedCertificate>($"/api/v1/pki/subscribers/{options.SubscriberName}/issue-certificate", options, true);
+      var response = await _apiClient.PostAsync<IssueCertificateOptions, SubscriberIssuedCertificate>($"/api/v1/pki/subscribers/{options.SubscriberName}/issue-certificate", options, true).ConfigureAwait(false);
 
       return response;
     }

--- a/src/Infisical.Sdk/Client/SecretsClient.cs
+++ b/src/Infisical.Sdk/Client/SecretsClient.cs
@@ -25,7 +25,7 @@ public class SecretsClient
         dict["tagSlugs"] = string.Join(",", options.TagSlugs);
       }
 
-      var response = await _apiClient.GetAsync<ListSecretsResponse>("/api/v3/secrets/raw", dict);
+      var response = await _apiClient.GetAsync<ListSecretsResponse>("/api/v3/secrets/raw", dict).ConfigureAwait(false);
 
 
       List<Secret> secrets = response.Secrets.ToList();
@@ -92,7 +92,7 @@ public class SecretsClient
 
       var dict = ObjectToDictionaryConverter.ToDictionary(options, false);
 
-      var response = await _apiClient.GetAsync<GetSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", dict);
+      var response = await _apiClient.GetAsync<GetSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", dict).ConfigureAwait(false);
 
       if (string.IsNullOrEmpty(response.Secret.SecretPath))
       {
@@ -114,7 +114,7 @@ public class SecretsClient
 
       options.Validate();
 
-      var response = await _apiClient.PostAsync<CreateSecretOptions, CreateSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", options, true);
+      var response = await _apiClient.PostAsync<CreateSecretOptions, CreateSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", options, true).ConfigureAwait(false);
       return response.Secret;
     }
     catch (Exception e)
@@ -129,7 +129,7 @@ public class SecretsClient
     {
       options.Validate();
 
-      var response = await _apiClient.PatchAsync<UpdateSecretOptions, UpdateSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", options, true);
+      var response = await _apiClient.PatchAsync<UpdateSecretOptions, UpdateSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", options, true).ConfigureAwait(false);
 
       return response.Secret;
     }
@@ -144,7 +144,7 @@ public class SecretsClient
     try
     {
       options.Validate();
-      var response = await _apiClient.DeleteAsync<DeleteSecretOptions, DeleteSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", options, true);
+      var response = await _apiClient.DeleteAsync<DeleteSecretOptions, DeleteSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", options, true).ConfigureAwait(false);
       return response.Secret;
     }
     catch (Exception e)


### PR DESCRIPTION
This PR updates async tasks in our sdk to use `.ConfigureAwait(false)` to prevent deadlock when called in a synchronous context. Includes deadlock test project.