### PR TITLE
fix: remove overly broad retry policy that retries all non-2xx responses

### DIFF
--- a/src/Infisical.Sdk/Api/ApiClient.cs
+++ b/src/Infisical.Sdk/Api/ApiClient.cs
@@ -23,7 +23,6 @@ namespace Infisical.Sdk.Api
     private static readonly IAsyncPolicy<HttpResponseMessage> RetryPolicy =
     HttpPolicyExtensions
         .HandleTransientHttpError() // HttpRequestException and 5XX/408 responses
-        .OrResult(msg => !msg.IsSuccessStatusCode)
         .WaitAndRetryAsync(3, retryAttempt =>
             TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
 


### PR DESCRIPTION
## Summary
Fixes #11 
## Problem
The `RetryPolicy` in `ApiClient.cs` uses `.OrResult(msg => !msg.IsSuccessStatusCode)` which causes Polly to retry on **all** non-2xx status codes (404, 401, 403, etc.). Combined with exponential backoff, this results in ~14-second delays for simple 404 responses.

## Root Cause
`HandleTransientHttpError()` already handles true transient errors (5xx + 408). The `.OrResult()` clause was redundant and harmful - it broadened the retry scope to include client errors that should fail immediately.

## Fix
Remove the `.OrResult(msg => !msg.IsSuccessStatusCode)` clause, preserving only `HandleTransientHttpError()` for genuine transient error handling.

## Testing
- Build verified across all 5 target frameworks (netstandard2.0, netstandard2.1, net6.0, net7.0, net8.0)
- - 0 warnings, 0 errors