### PR TITLE
feat: add ProjectSlug as an alternative to ProjectId across all secret operations

### DIFF
--- a/src/Infisical.Sdk/Client/SecretsClient.cs
+++ b/src/Infisical.Sdk/Client/SecretsClient.cs
@@ -29,8 +29,19 @@ public class SecretsClient
 
     try
     {
-      var response = await _apiClient.GetAsync<ProjectBySlugResponse>($"/api/v1/projects/slug/{projectSlug}").ConfigureAwait(false);
+      var escapedSlug = Uri.EscapeDataString(projectSlug);
+      var response = await _apiClient.GetAsync<ProjectBySlugResponse>($"/api/v1/projects/slug/{escapedSlug}").ConfigureAwait(false);
+
+      if (string.IsNullOrEmpty(response.Id))
+      {
+        throw new InfisicalException($"Project slug '{projectSlug}' resolved to an empty project ID");
+      }
+
       return response.Id;
+    }
+    catch (InfisicalException)
+    {
+      throw;
     }
     catch (Exception e)
     {

--- a/src/Infisical.Sdk/Client/SecretsClient.cs
+++ b/src/Infisical.Sdk/Client/SecretsClient.cs
@@ -11,11 +11,41 @@ public class SecretsClient
     _apiClient = apiClient;
   }
 
+  /// <summary>
+  /// Resolves a project slug to a project ID by calling the Infisical API.
+  /// If ProjectId is already set, this is a no-op.
+  /// </summary>
+  private async Task<string> ResolveProjectIdAsync(string? projectId, string? projectSlug)
+  {
+    if (!string.IsNullOrEmpty(projectId))
+    {
+      return projectId!;
+    }
+
+    if (string.IsNullOrEmpty(projectSlug))
+    {
+      throw new InfisicalException("Either ProjectId or ProjectSlug is required");
+    }
+
+    try
+    {
+      var response = await _apiClient.GetAsync<ProjectBySlugResponse>($"/api/v1/projects/slug/{projectSlug}").ConfigureAwait(false);
+      return response.Id;
+    }
+    catch (Exception e)
+    {
+      throw new InfisicalException($"Failed to resolve project slug '{projectSlug}' to a project ID", e);
+    }
+  }
+
   public async Task<Secret[]> ListAsync(ListSecretsOptions options)
   {
     try
     {
       options.Validate();
+
+      // Resolve ProjectSlug to ProjectId if needed
+      options.ProjectId = await ResolveProjectIdAsync(options.ProjectId, options.ProjectSlug).ConfigureAwait(false);
 
       var dict = ObjectToDictionaryConverter.ToDictionary(options, false);
       dict.Remove("tagSlugs");
@@ -90,6 +120,9 @@ public class SecretsClient
 
       options.Validate();
 
+      // Resolve ProjectSlug to ProjectId if needed
+      options.ProjectId = await ResolveProjectIdAsync(options.ProjectId, options.ProjectSlug).ConfigureAwait(false);
+
       var dict = ObjectToDictionaryConverter.ToDictionary(options, false);
 
       var response = await _apiClient.GetAsync<GetSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", dict).ConfigureAwait(false);
@@ -114,6 +147,9 @@ public class SecretsClient
 
       options.Validate();
 
+      // Resolve ProjectSlug to ProjectId if needed
+      options.ProjectId = await ResolveProjectIdAsync(options.ProjectId, options.ProjectSlug).ConfigureAwait(false);
+
       var response = await _apiClient.PostAsync<CreateSecretOptions, CreateSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", options, true).ConfigureAwait(false);
       return response.Secret;
     }
@@ -128,6 +164,9 @@ public class SecretsClient
     try
     {
       options.Validate();
+
+      // Resolve ProjectSlug to ProjectId if needed
+      options.ProjectId = await ResolveProjectIdAsync(options.ProjectId, options.ProjectSlug).ConfigureAwait(false);
 
       var response = await _apiClient.PatchAsync<UpdateSecretOptions, UpdateSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", options, true).ConfigureAwait(false);
 
@@ -144,6 +183,10 @@ public class SecretsClient
     try
     {
       options.Validate();
+
+      // Resolve ProjectSlug to ProjectId if needed
+      options.ProjectId = await ResolveProjectIdAsync(options.ProjectId, options.ProjectSlug).ConfigureAwait(false);
+
       var response = await _apiClient.DeleteAsync<DeleteSecretOptions, DeleteSecretResponse>($"/api/v3/secrets/raw/{options.SecretName}", options, true).ConfigureAwait(false);
       return response.Secret;
     }

--- a/src/Infisical.Sdk/Model/Api.cs
+++ b/src/Infisical.Sdk/Model/Api.cs
@@ -81,7 +81,15 @@ public class ListSecretsOptions
   public bool SetSecretsAsEnvironmentVariables { get; set; } = false;
 
   [JsonPropertyName("workspaceId")]
-  public string? ProjectId { get; init; } = null;
+  public string? ProjectId { get; set; } = null;
+
+  /// <summary>
+  /// The human-readable slug of the project. Can be used as an alternative to ProjectId.
+  /// If both ProjectId and ProjectSlug are provided, ProjectId takes precedence.
+  /// </summary>
+  [JsonIgnore]
+  public string? ProjectSlug { get; init; } = null;
+
   [JsonPropertyName("environment")]
   public string? EnvironmentSlug { get; init; } = null;
   [JsonPropertyName("secretPath")]
@@ -100,9 +108,9 @@ public class ListSecretsOptions
   internal void Validate()
   {
 
-    if (string.IsNullOrEmpty(ProjectId))
+    if (string.IsNullOrEmpty(ProjectId) && string.IsNullOrEmpty(ProjectSlug))
     {
-      throw new InfisicalException("ProjectId is required");
+      throw new InfisicalException("Either ProjectId or ProjectSlug is required");
     }
 
     if (string.IsNullOrEmpty(EnvironmentSlug))
@@ -120,7 +128,14 @@ public class ListSecretsOptions
 public class GetSecretOptions
 {
   [JsonPropertyName("workspaceId")]
-  public string? ProjectId { get; init; } = null;
+  public string? ProjectId { get; set; } = null;
+
+  /// <summary>
+  /// The human-readable slug of the project. Can be used as an alternative to ProjectId.
+  /// If both ProjectId and ProjectSlug are provided, ProjectId takes precedence.
+  /// </summary>
+  [JsonIgnore]
+  public string? ProjectSlug { get; init; } = null;
 
   [JsonPropertyName("environment")]
   public string? EnvironmentSlug { get; init; } = null;
@@ -148,9 +163,9 @@ public class GetSecretOptions
 
   internal void Validate()
   {
-    if (string.IsNullOrEmpty(ProjectId))
+    if (string.IsNullOrEmpty(ProjectId) && string.IsNullOrEmpty(ProjectSlug))
     {
-      throw new InfisicalException("ProjectId is required");
+      throw new InfisicalException("Either ProjectId or ProjectSlug is required");
     }
 
     if (string.IsNullOrEmpty(EnvironmentSlug))
@@ -176,7 +191,14 @@ public class CreateSecretOptions
   public string SecretName { get; init; } = string.Empty;
 
   [JsonPropertyName("workspaceId")]
-  public string? ProjectId { get; init; } = null;
+  public string? ProjectId { get; set; } = null;
+
+  /// <summary>
+  /// The human-readable slug of the project. Can be used as an alternative to ProjectId.
+  /// If both ProjectId and ProjectSlug are provided, ProjectId takes precedence.
+  /// </summary>
+  [JsonIgnore]
+  public string? ProjectSlug { get; init; } = null;
 
   [JsonPropertyName("environment")]
   public string? EnvironmentSlug { get; init; } = null;
@@ -207,9 +229,9 @@ public class CreateSecretOptions
 
   internal void Validate()
   {
-    if (string.IsNullOrEmpty(ProjectId))
+    if (string.IsNullOrEmpty(ProjectId) && string.IsNullOrEmpty(ProjectSlug))
     {
-      throw new InfisicalException("ProjectId is required");
+      throw new InfisicalException("Either ProjectId or ProjectSlug is required");
     }
 
     if (string.IsNullOrEmpty(EnvironmentSlug))
@@ -243,7 +265,14 @@ public class UpdateSecretOptions
   public string? NewSecretName { get; init; } = null;
 
   [JsonPropertyName("workspaceId")]
-  public string? ProjectId { get; init; } = null;
+  public string? ProjectId { get; set; } = null;
+
+  /// <summary>
+  /// The human-readable slug of the project. Can be used as an alternative to ProjectId.
+  /// If both ProjectId and ProjectSlug are provided, ProjectId takes precedence.
+  /// </summary>
+  [JsonIgnore]
+  public string? ProjectSlug { get; init; } = null;
 
   [JsonPropertyName("environment")]
   public string? EnvironmentSlug { get; init; } = null;
@@ -274,9 +303,9 @@ public class UpdateSecretOptions
 
   internal void Validate()
   {
-    if (string.IsNullOrEmpty(ProjectId))
+    if (string.IsNullOrEmpty(ProjectId) && string.IsNullOrEmpty(ProjectSlug))
     {
-      throw new InfisicalException("ProjectId is required");
+      throw new InfisicalException("Either ProjectId or ProjectSlug is required");
     }
 
     if (string.IsNullOrEmpty(SecretName))
@@ -302,7 +331,14 @@ public class DeleteSecretOptions
   public string SecretName { get; init; } = string.Empty;
 
   [JsonPropertyName("workspaceId")]
-  public string? ProjectId { get; init; } = null;
+  public string? ProjectId { get; set; } = null;
+
+  /// <summary>
+  /// The human-readable slug of the project. Can be used as an alternative to ProjectId.
+  /// If both ProjectId and ProjectSlug are provided, ProjectId takes precedence.
+  /// </summary>
+  [JsonIgnore]
+  public string? ProjectSlug { get; init; } = null;
 
   [JsonPropertyName("environment")]
   public string? EnvironmentSlug { get; init; } = null;
@@ -312,9 +348,9 @@ public class DeleteSecretOptions
 
   internal void Validate()
   {
-    if (string.IsNullOrEmpty(ProjectId))
+    if (string.IsNullOrEmpty(ProjectId) && string.IsNullOrEmpty(ProjectSlug))
     {
-      throw new InfisicalException("ProjectId is required");
+      throw new InfisicalException("Either ProjectId or ProjectSlug is required");
     }
 
     if (string.IsNullOrEmpty(SecretName))
@@ -509,4 +545,16 @@ class DeleteSecretResponse
 {
   [JsonPropertyName("secret")]
   public Secret Secret { get; set; } = new Secret();
+}
+
+class ProjectBySlugResponse
+{
+  [JsonPropertyName("id")]
+  public string Id { get; set; } = string.Empty;
+
+  [JsonPropertyName("name")]
+  public string Name { get; set; } = string.Empty;
+
+  [JsonPropertyName("slug")]
+  public string Slug { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
Fixes #2 
## Problem
Users are forced to use unfriendly project GUIDs (e.g. `3c90c3cc-0d44-4b50-8888-8dd25736052a`) in their application configuration. The `ListSecretsOptions` (and other options classes) only accept `ProjectId`, with no support for the human-readable project slug.

## Solution
Added a `ProjectSlug` property to all secret operation option classes. When provided, the SDK transparently resolves it to a `ProjectId` via `GET /api/v1/projects/slug/{slug}` before calling the secrets API.

### Changes:
- Added `ProjectSlug` property to `ListSecretsOptions`, `GetSecretOptions`, `CreateSecretOptions`, `UpdateSecretOptions`, and `DeleteSecretOptions`
- - Added `ResolveProjectIdAsync` method in `SecretsClient` for automatic slug-to-ID resolution
- - Updated validation to accept either `ProjectId` or `ProjectSlug`
- - Added `ProjectBySlugResponse` model
### Usage:
```csharp
var options = new ListSecretsOptions
{
    ProjectSlug = "my-project",
    EnvironmentSlug = "dev",
    SecretPath = "/",
};
```

## Testing
- Build verified across all 5 target frameworks (netstandard2.0, netstandard2.1, net6.0, net7.0, net8.0)
- - 0 warnings, 0 errors