### PR TITLE
fix: preserve secrets with same name across different folders during recursive listing

### DIFF
--- a/src/Infisical.Sdk/Util/Secrets.cs
+++ b/src/Infisical.Sdk/Util/Secrets.cs
@@ -15,7 +15,7 @@ namespace Infisical.Sdk.Util
       var secretMap = new Dictionary<string, Secret>();
       foreach (var secret in secrets)
       {
-        var compositeKey = $"{secret.SecretPath}:{secret.SecretKey}";
+        var compositeKey = $"{secret.SecretPath}\0{secret.SecretKey}";
         secretMap[compositeKey] = secret;
       }
 

--- a/src/Infisical.Sdk/Util/Secrets.cs
+++ b/src/Infisical.Sdk/Util/Secrets.cs
@@ -6,13 +6,17 @@ namespace Infisical.Sdk.Util
   public static class SecretsUtil
   {
 
-    // currently the last secret in the list is kept
+    // Deduplicates secrets using a composite key of SecretPath + SecretKey.
+    // This ensures secrets with the same name in different folders
+    // (e.g. /elasticsearch/username and /postgres/username) are preserved.
+    // When duplicates exist at the same path, the last secret in the list is kept.
     public static void EnsureUniqueSecretsByKey(IList<Secret> secrets)
     {
       var secretMap = new Dictionary<string, Secret>();
       foreach (var secret in secrets)
       {
-        secretMap[secret.SecretKey] = secret;
+        var compositeKey = $"{secret.SecretPath}:{secret.SecretKey}";
+        secretMap[compositeKey] = secret;
       }
 
       secrets.Clear();


### PR DESCRIPTION
## Summary
Fixes #1 
## Problem
When using ListAsync with Recursive = true, secrets with the same key name but in different folders (e.g., /elasticsearch/username and /postgres/username) are silently dropped.

Root cause: EnsureUniqueSecretsByKey uses only SecretKey as the dictionary key, so secretMap["username"] gets overwritten - the second folder's secret replaces the first.

## Solution
Changed the deduplication key from SecretKey alone to a composite key of SecretPath:SecretKey. This means:
- /elasticsearch/username -> key = /elasticsearch:username
- - /postgres/username -> key = /postgres:username
These are now treated as distinct entries. Secrets are only deduplicated when they share both the same name and the same path.

Before:
secretMap[secret.SecretKey] = secret;  // "username" overwrites "username"

After:
var compositeKey = $"{secret.SecretPath}:{secret.SecretKey}";
secretMap[compositeKey] = secret;  // "/elasticsearch:username" != "/postgres:username"

## Testing
- Build verified across all 5 target frameworks (netstandard2.0, netstandard2.1, net6.0, net7.0, net8.0)
- - 0 warnings, 0 errors