### PR TITLE
fix: add folders client

### DIFF
--- a/src/Infisical.Sdk.Test/Program.cs
+++ b/src/Infisical.Sdk.Test/Program.cs
@@ -13,7 +13,7 @@ internal class Program
         .Select(s => s[Random.Shared.Next(s.Length)]).ToArray());
   }
 
-  private static void Main(string[] args)
+  private static async Task Main(string[] args)
   {
 
     var machineIdentityClientId = Environment.GetEnvironmentVariable("INFISICAL_MACHINE_IDENTITY_CLIENT_ID");
@@ -39,7 +39,7 @@ internal class Program
 
 
     var client = new InfisicalClient(settings);
-    var _ = client.Auth().UniversalAuth().LoginAsync(machineIdentityClientId, machineIdentityClientSecret).Result;
+    var _ = await client.Auth().UniversalAuth().LoginAsync(machineIdentityClientId, machineIdentityClientSecret);
 
     // sleep for 10 seconds
     Console.WriteLine("Sleeping for 5 seconds");
@@ -64,7 +64,7 @@ internal class Program
     };
 
     Console.WriteLine("\n\n\nEnsure folder path response:");
-    Console.WriteLine(JsonSerializer.Serialize(client.Folders().EnsurePathAsync(ensureFolderPathOptions).Result, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine(JsonSerializer.Serialize(await client.Folders().EnsurePathAsync(ensureFolderPathOptions), new JsonSerializerOptions { WriteIndented = true }));
 
     var newSecretName = $".NET-SDK-TEST-{RandomString(32)}";
 
@@ -78,7 +78,7 @@ internal class Program
     };
 
     Console.WriteLine("\n\n\nCreate secret response:");
-    Console.WriteLine(JsonSerializer.Serialize(client.Secrets().CreateAsync(createSecretOptions).Result, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine(JsonSerializer.Serialize(await client.Secrets().CreateAsync(createSecretOptions), new JsonSerializerOptions { WriteIndented = true }));
 
     var options = new ListSecretsOptions
     {
@@ -91,7 +91,7 @@ internal class Program
       // ViewSecretValue = true,
     };
     Console.WriteLine("\n\n\nList secrets response:");
-    Console.WriteLine(JsonSerializer.Serialize(client.Secrets().ListAsync(options).Result, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine(JsonSerializer.Serialize(await client.Secrets().ListAsync(options), new JsonSerializerOptions { WriteIndented = true }));
 
     var getSecretOptions = new GetSecretOptions
     {
@@ -101,7 +101,7 @@ internal class Program
       ProjectId = projectId,
     };
     Console.WriteLine("\n\n\nGet secret response:");
-    Console.WriteLine(JsonSerializer.Serialize(client.Secrets().GetAsync(getSecretOptions).Result, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine(JsonSerializer.Serialize(await client.Secrets().GetAsync(getSecretOptions), new JsonSerializerOptions { WriteIndented = true }));
 
 
     // Close the Universal Auth client and create a new one with LDAP Auth
@@ -123,7 +123,7 @@ internal class Program
       try
       {
         Console.WriteLine("Authenticating with LDAP...");
-        var ldapCredential = ldapClient.Auth().LdapAuth().LoginAsync(ldapIdentityId, ldapUsername, ldapPassword).Result;
+        var ldapCredential = await ldapClient.Auth().LdapAuth().LoginAsync(ldapIdentityId, ldapUsername, ldapPassword);
         Console.WriteLine($"✅ LDAP Auth successful! Token: {ldapCredential.AccessToken.Substring(0, Math.Min(20, ldapCredential.AccessToken.Length))}...");
         Console.WriteLine($"   Expires In: {ldapCredential.ExpiresIn} seconds");
         
@@ -152,7 +152,7 @@ internal class Program
     };
 
     Console.WriteLine("\n\n\nUpdate secret response:");
-    Console.WriteLine(JsonSerializer.Serialize(client.Secrets().UpdateAsync(updateSecretOptions).Result, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine(JsonSerializer.Serialize(await client.Secrets().UpdateAsync(updateSecretOptions), new JsonSerializerOptions { WriteIndented = true }));
 
 
     var deleteSecretOptions = new DeleteSecretOptions
@@ -164,6 +164,6 @@ internal class Program
     };
 
     Console.WriteLine("\n\n\nDelete secret response:");
-    Console.WriteLine(JsonSerializer.Serialize(client.Secrets().DeleteAsync(deleteSecretOptions).Result, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine(JsonSerializer.Serialize(await client.Secrets().DeleteAsync(deleteSecretOptions), new JsonSerializerOptions { WriteIndented = true }));
   }
 }

--- a/src/Infisical.Sdk.Test/Program.cs
+++ b/src/Infisical.Sdk.Test/Program.cs
@@ -54,13 +54,25 @@ internal class Program
       Console.WriteLine($"{envVar} {Environment.NewLine}");
     }
 
+    var folderPath = $"/test/{RandomString(8)}";
+    var ensureFolderPathOptions = new EnsureFolderPathOptions
+    {
+      EnvironmentSlug = "dev",
+      Path = folderPath,
+      ProjectId = projectId,
+      Description = ".NET SDK sample folder"
+    };
+
+    Console.WriteLine("\n\n\nEnsure folder path response:");
+    Console.WriteLine(JsonSerializer.Serialize(client.Folders().EnsurePathAsync(ensureFolderPathOptions).Result, new JsonSerializerOptions { WriteIndented = true }));
+
     var newSecretName = $".NET-SDK-TEST-{RandomString(32)}";
 
     var createSecretOptions = new CreateSecretOptions
     {
       SecretName = newSecretName,
       EnvironmentSlug = "dev",
-      SecretPath = "/test",
+      SecretPath = folderPath,
       SecretValue = RandomString(10),
       ProjectId = projectId,
     };
@@ -72,7 +84,7 @@ internal class Program
     {
       SetSecretsAsEnvironmentVariables = true,
       EnvironmentSlug = "dev",
-      SecretPath = "/test",
+      SecretPath = folderPath,
       Recursive = true,
       // ExpandSecretReferences = true,
       ProjectId = projectId,
@@ -85,7 +97,7 @@ internal class Program
     {
       SecretName = newSecretName,
       EnvironmentSlug = "dev",
-      SecretPath = "/test",
+      SecretPath = folderPath,
       ProjectId = projectId,
     };
     Console.WriteLine("\n\n\nGet secret response:");
@@ -133,7 +145,7 @@ internal class Program
     {
       SecretName = newSecretName,
       EnvironmentSlug = "dev",
-      SecretPath = "/test",
+      SecretPath = folderPath,
       NewSecretName = $"{newSecretName}-updated-name",
       NewSecretValue = $"{RandomString(10)}-updated-value",
       ProjectId = projectId,
@@ -147,7 +159,7 @@ internal class Program
     {
       SecretName = $"{newSecretName}-updated-name",
       EnvironmentSlug = "dev",
-      SecretPath = "/test",
+      SecretPath = folderPath,
       ProjectId = projectId,
     };
 

--- a/src/Infisical.Sdk/Api/ApiClient.cs
+++ b/src/Infisical.Sdk/Api/ApiClient.cs
@@ -92,51 +92,61 @@ namespace Infisical.Sdk.Api
       return message;
     }
 
+    internal async Task<ApiResponse<TResponse>> PostForResponseAsync<TRequest, TResponse>(string url, TRequest requestBody, bool omitNullValues = false)
+    {
+      var jsonContent = omitNullValues ? JsonSerializer.Serialize(requestBody, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull }) : JsonSerializer.Serialize(requestBody);
+      var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
+
+      var request = new HttpRequestMessage(HttpMethod.Post, new Uri(new Uri(_baseUrl), url))
+      {
+        Content = content
+      };
+
+      request.Headers.Add("Accept", "application/json");
+
+      if (!string.IsNullOrEmpty(_accessToken))
+      {
+        request.Headers.Add("Authorization", $"Bearer {_accessToken}");
+      }
+
+      var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+      var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+      if (!response.IsSuccessStatusCode)
+      {
+        return ApiResponse<TResponse>.Failure(response.StatusCode, response.ReasonPhrase, responseContent);
+      }
+
+      if (string.IsNullOrEmpty(responseContent))
+      {
+        throw new HttpRequestException("Response body is null or empty");
+      }
+
+      var result = JsonSerializer.Deserialize<TResponse>(responseContent, new JsonSerializerOptions
+      {
+        PropertyNameCaseInsensitive = true
+      });
+
+      if (result == null)
+      {
+        throw new InfisicalException("Failed to deserialize response content");
+      }
+
+      return ApiResponse<TResponse>.Success(response.StatusCode, response.ReasonPhrase, responseContent, result);
+    }
+
     public async Task<TResponse> PostAsync<TRequest, TResponse>(string url, TRequest requestBody, bool omitNullValues = false)
     {
       try
       {
-        var jsonContent = omitNullValues ? JsonSerializer.Serialize(requestBody, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull }) : JsonSerializer.Serialize(requestBody);
-        var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
-
-        var request = new HttpRequestMessage(HttpMethod.Post, new Uri(new Uri(_baseUrl), url))
-        {
-          Content = content
-        };
-
-        request.Headers.Add("Accept", "application/json");
-
-        if (!string.IsNullOrEmpty(_accessToken))
-        {
-          request.Headers.Add("Authorization", $"Bearer {_accessToken}");
-        }
-
-        var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+        var response = await PostForResponseAsync<TRequest, TResponse>(url, requestBody, omitNullValues).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
-          var errorMessage = await FormatErrorMessageAsync(response).ConfigureAwait(false);
-          throw new HttpRequestException(errorMessage);
+          throw new HttpRequestException(response.FormatErrorMessage());
         }
 
-        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-        if (string.IsNullOrEmpty(responseContent))
-        {
-          throw new HttpRequestException("Response body is null or empty");
-        }
-
-        var result = JsonSerializer.Deserialize<TResponse>(responseContent, new JsonSerializerOptions
-        {
-          PropertyNameCaseInsensitive = true
-        });
-
-        if (result == null)
-        {
-          throw new InfisicalException("Failed to deserialize response content");
-        }
-
-        return result;
+        return response.Value!;
       }
       catch (Exception ex) when (!(ex is InfisicalException))
       {
@@ -332,6 +342,45 @@ namespace Infisical.Sdk.Api
     public Dictionary<string, string> Build()
     {
       return new Dictionary<string, string>(_params);
+    }
+  }
+
+  internal class ApiResponse<T>
+  {
+    private ApiResponse(System.Net.HttpStatusCode statusCode, string? reasonPhrase, string content, T? value, bool isSuccessStatusCode)
+    {
+      StatusCode = statusCode;
+      ReasonPhrase = reasonPhrase;
+      Content = content;
+      Value = value;
+      IsSuccessStatusCode = isSuccessStatusCode;
+    }
+
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public string? ReasonPhrase { get; }
+    public string Content { get; }
+    public T? Value { get; }
+    public bool IsSuccessStatusCode { get; }
+
+    public static ApiResponse<T> Success(System.Net.HttpStatusCode statusCode, string? reasonPhrase, string content, T value)
+    {
+      return new ApiResponse<T>(statusCode, reasonPhrase, content, value, true);
+    }
+
+    public static ApiResponse<T> Failure(System.Net.HttpStatusCode statusCode, string? reasonPhrase, string content)
+    {
+      return new ApiResponse<T>(statusCode, reasonPhrase, content, default, false);
+    }
+
+    public string FormatErrorMessage()
+    {
+      var message = $"Unexpected response: {StatusCode} {ReasonPhrase}";
+      if (!string.IsNullOrEmpty(Content))
+      {
+        message += $" - {Content}";
+      }
+
+      return message;
     }
   }
 }

--- a/src/Infisical.Sdk/Client/FoldersClient.cs
+++ b/src/Infisical.Sdk/Client/FoldersClient.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using Infisical.Sdk.Api;
 using Infisical.Sdk.Model;
 
@@ -28,13 +29,36 @@ public class FoldersClient
     }
   }
 
+  public async Task<InfisicalFolder[]> ListAsync(ListFoldersOptions options)
+  {
+    try
+    {
+      options.Validate();
+
+      var queryParams = new Dictionary<string, string>
+      {
+        ["projectId"] = options.ProjectId!,
+        ["environment"] = options.EnvironmentSlug!,
+        ["path"] = options.Path,
+        ["recursive"] = options.Recursive.ToString().ToLowerInvariant()
+      };
+
+      var response = await _apiClient.GetAsync<ListFoldersResponse>("/api/v2/folders", queryParams).ConfigureAwait(false);
+      return response.Folders;
+    }
+    catch (Exception e)
+    {
+      throw new InfisicalException("Failed to list folders", e);
+    }
+  }
+
   public async Task<IReadOnlyList<InfisicalFolder>> EnsurePathAsync(EnsureFolderPathOptions options)
   {
     try
     {
       options.Validate();
 
-      var createdFolders = new List<InfisicalFolder>();
+      var ensuredFolders = new List<InfisicalFolder>();
       var parentPath = "/";
       var segments = options.Path
         .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
@@ -44,6 +68,14 @@ public class FoldersClient
 
       foreach (var segment in segments)
       {
+        var existingFolder = await FindFolderAsync(options.ProjectId!, options.EnvironmentSlug!, parentPath, segment).ConfigureAwait(false);
+        if (existingFolder != null)
+        {
+          ensuredFolders.Add(existingFolder);
+          parentPath = AppendPathSegment(parentPath, segment);
+          continue;
+        }
+
         var createOptions = new CreateFolderOptions
         {
           ProjectId = options.ProjectId,
@@ -56,17 +88,27 @@ public class FoldersClient
         var response = await _apiClient.PostForResponseAsync<CreateFolderOptions, CreateFolderResponse>("/api/v2/folders", createOptions, true).ConfigureAwait(false);
         if (response.IsSuccessStatusCode)
         {
-          createdFolders.Add(response.Value!.Folder);
+          ensuredFolders.Add(response.Value!.Folder);
+          parentPath = AppendPathSegment(parentPath, segment);
+          continue;
         }
-        else if (!IsAlreadyExistsResponse(response.StatusCode, response.Content))
+
+        if (!IsAlreadyExistsResponse(response.StatusCode, response.Content))
         {
           throw new InfisicalException(response.FormatErrorMessage());
         }
 
-        parentPath = parentPath == "/" ? "/" + segment : parentPath + "/" + segment;
+        existingFolder = await FindFolderAsync(options.ProjectId!, options.EnvironmentSlug!, parentPath, segment).ConfigureAwait(false);
+        if (existingFolder == null)
+        {
+          throw new InfisicalException($"Infisical reported folder '{segment}' already exists under '{parentPath}', but listing the parent path did not return it.");
+        }
+
+        ensuredFolders.Add(existingFolder);
+        parentPath = AppendPathSegment(parentPath, segment);
       }
 
-      return createdFolders;
+      return ensuredFolders;
     }
     catch (Exception e) when (!(e is InfisicalException))
     {
@@ -81,8 +123,54 @@ public class FoldersClient
       return false;
     }
 
-    return responseBody.IndexOf("already exists", StringComparison.OrdinalIgnoreCase) >= 0 ||
-           responseBody.IndexOf("folder already", StringComparison.OrdinalIgnoreCase) >= 0 ||
-           responseBody.IndexOf("duplicate", StringComparison.OrdinalIgnoreCase) >= 0;
+    var apiError = TryParseApiError(responseBody);
+    if (apiError == null)
+    {
+      return false;
+    }
+
+    if (apiError.StatusCode.HasValue && apiError.StatusCode.Value != (int)statusCode)
+    {
+      return false;
+    }
+
+    var message = apiError.Message ?? string.Empty;
+    return message.IndexOf("folder", StringComparison.OrdinalIgnoreCase) >= 0 &&
+           message.IndexOf("already exist", StringComparison.OrdinalIgnoreCase) >= 0;
+  }
+
+  private async Task<InfisicalFolder?> FindFolderAsync(string projectId, string environmentSlug, string parentPath, string folderName)
+  {
+    var folders = await ListAsync(new ListFoldersOptions
+    {
+      ProjectId = projectId,
+      EnvironmentSlug = environmentSlug,
+      Path = parentPath,
+      Recursive = false
+    }).ConfigureAwait(false);
+
+    return folders.FirstOrDefault(folder =>
+      string.Equals(folder.Name, folderName, StringComparison.Ordinal) ||
+      string.Equals(folder.RelativePath, AppendPathSegment(parentPath, folderName), StringComparison.Ordinal));
+  }
+
+  private static string AppendPathSegment(string parentPath, string segment)
+  {
+    return parentPath == "/" ? "/" + segment : parentPath + "/" + segment;
+  }
+
+  private static FolderApiError? TryParseApiError(string responseBody)
+  {
+    try
+    {
+      return JsonSerializer.Deserialize<FolderApiError>(responseBody, new JsonSerializerOptions
+      {
+        PropertyNameCaseInsensitive = true
+      });
+    }
+    catch (JsonException)
+    {
+      return null;
+    }
   }
 }

--- a/src/Infisical.Sdk/Client/FoldersClient.cs
+++ b/src/Infisical.Sdk/Client/FoldersClient.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using Infisical.Sdk.Api;
+using Infisical.Sdk.Model;
+
+namespace Infisical.Sdk.Client;
+
+public class FoldersClient
+{
+  private readonly ApiClient _apiClient;
+
+  public FoldersClient(ApiClient apiClient)
+  {
+    _apiClient = apiClient;
+  }
+
+  public async Task<InfisicalFolder> CreateAsync(CreateFolderOptions options)
+  {
+    try
+    {
+      options.Validate();
+
+      var response = await _apiClient.PostAsync<CreateFolderOptions, CreateFolderResponse>("/api/v2/folders", options, true).ConfigureAwait(false);
+      return response.Folder;
+    }
+    catch (Exception e)
+    {
+      throw new InfisicalException("Failed to create folder", e);
+    }
+  }
+
+  public async Task<IReadOnlyList<InfisicalFolder>> EnsurePathAsync(EnsureFolderPathOptions options)
+  {
+    try
+    {
+      options.Validate();
+
+      var createdFolders = new List<InfisicalFolder>();
+      var parentPath = "/";
+      var segments = options.Path
+        .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
+        .Select(segment => segment.Trim())
+        .Where(segment => !string.IsNullOrEmpty(segment))
+        .ToArray();
+
+      foreach (var segment in segments)
+      {
+        var createOptions = new CreateFolderOptions
+        {
+          ProjectId = options.ProjectId,
+          EnvironmentSlug = options.EnvironmentSlug,
+          Name = segment,
+          Path = parentPath,
+          Description = options.Description
+        };
+
+        var response = await _apiClient.PostForResponseAsync<CreateFolderOptions, CreateFolderResponse>("/api/v2/folders", createOptions, true).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+        {
+          createdFolders.Add(response.Value!.Folder);
+        }
+        else if (!IsAlreadyExistsResponse(response.StatusCode, response.Content))
+        {
+          throw new InfisicalException(response.FormatErrorMessage());
+        }
+
+        parentPath = parentPath == "/" ? "/" + segment : parentPath + "/" + segment;
+      }
+
+      return createdFolders;
+    }
+    catch (Exception e) when (!(e is InfisicalException))
+    {
+      throw new InfisicalException("Failed to ensure folder path", e);
+    }
+  }
+
+  internal static bool IsAlreadyExistsResponse(HttpStatusCode statusCode, string responseBody)
+  {
+    if (statusCode != HttpStatusCode.BadRequest && statusCode != HttpStatusCode.Conflict && (int)statusCode != 422)
+    {
+      return false;
+    }
+
+    return responseBody.IndexOf("already exists", StringComparison.OrdinalIgnoreCase) >= 0 ||
+           responseBody.IndexOf("folder already", StringComparison.OrdinalIgnoreCase) >= 0 ||
+           responseBody.IndexOf("duplicate", StringComparison.OrdinalIgnoreCase) >= 0;
+  }
+}

--- a/src/Infisical.Sdk/InfisicalClient.cs
+++ b/src/Infisical.Sdk/InfisicalClient.cs
@@ -11,12 +11,14 @@ namespace Infisical.Sdk
     private AuthClient _authClient;
     private SecretsClient _secretsClient;
     private PkiClient _pkiClient;
+    private FoldersClient _foldersClient;
     public InfisicalClient(InfisicalSdkSettings settings)
     {
       _apiClient = new ApiClient(settings.HostUri);
       _secretsClient = new SecretsClient(_apiClient);
       _authClient = new AuthClient(_apiClient, (accessToken) => _apiClient.SetAccessToken(accessToken));
       _pkiClient = new PkiClient(_apiClient);
+      _foldersClient = new FoldersClient(_apiClient);
     }
 
     public AuthClient Auth()
@@ -32,6 +34,11 @@ namespace Infisical.Sdk
     public PkiClient Pki()
     {
       return _pkiClient;
+    }
+
+    public FoldersClient Folders()
+    {
+      return _foldersClient;
     }
   }
 }

--- a/src/Infisical.Sdk/Model/Api.cs
+++ b/src/Infisical.Sdk/Model/Api.cs
@@ -336,6 +336,117 @@ public class DeleteSecretOptions
 
 }
 
+public class CreateFolderOptions
+{
+  [JsonPropertyName("projectId")]
+  public string? ProjectId { get; init; } = null;
+
+  [JsonPropertyName("environment")]
+  public string? EnvironmentSlug { get; init; } = null;
+
+  [JsonPropertyName("name")]
+  public string Name { get; init; } = string.Empty;
+
+  [JsonPropertyName("path")]
+  public string Path { get; init; } = "/";
+
+  [JsonPropertyName("description")]
+  public string? Description { get; init; } = null;
+
+  internal void Validate()
+  {
+    if (string.IsNullOrEmpty(ProjectId))
+    {
+      throw new InfisicalException("ProjectId is required");
+    }
+
+    if (string.IsNullOrEmpty(EnvironmentSlug))
+    {
+      throw new InfisicalException("EnvironmentSlug is required");
+    }
+
+    if (string.IsNullOrEmpty(Name))
+    {
+      throw new InfisicalException("Name is required");
+    }
+
+    if (string.IsNullOrEmpty(Path))
+    {
+      throw new InfisicalException("Path is required");
+    }
+  }
+}
+
+public class EnsureFolderPathOptions
+{
+  [JsonPropertyName("projectId")]
+  public string? ProjectId { get; init; } = null;
+
+  [JsonPropertyName("environment")]
+  public string? EnvironmentSlug { get; init; } = null;
+
+  [JsonPropertyName("path")]
+  public string Path { get; init; } = "/";
+
+  [JsonPropertyName("description")]
+  public string? Description { get; init; } = null;
+
+  internal void Validate()
+  {
+    if (string.IsNullOrEmpty(ProjectId))
+    {
+      throw new InfisicalException("ProjectId is required");
+    }
+
+    if (string.IsNullOrEmpty(EnvironmentSlug))
+    {
+      throw new InfisicalException("EnvironmentSlug is required");
+    }
+
+    if (string.IsNullOrEmpty(Path))
+    {
+      throw new InfisicalException("Path is required");
+    }
+  }
+}
+
+public class InfisicalFolder
+{
+  [JsonPropertyName("id")]
+  public string Id { get; set; } = string.Empty;
+
+  [JsonPropertyName("name")]
+  public string Name { get; set; } = string.Empty;
+
+  [JsonPropertyName("version")]
+  public decimal? Version { get; set; } = null;
+
+  [JsonPropertyName("createdAt")]
+  public DateTime CreatedAt { get; set; }
+
+  [JsonPropertyName("updatedAt")]
+  public DateTime UpdatedAt { get; set; }
+
+  [JsonPropertyName("envId")]
+  public string EnvironmentId { get; set; } = string.Empty;
+
+  [JsonPropertyName("parentId")]
+  public string? ParentId { get; set; } = null;
+
+  [JsonPropertyName("isReserved")]
+  public bool? IsReserved { get; set; } = null;
+
+  [JsonPropertyName("description")]
+  public string? Description { get; set; } = null;
+
+  [JsonPropertyName("lastSecretModified")]
+  public DateTime? LastSecretModified { get; set; } = null;
+
+  [JsonPropertyName("path")]
+  public string Path { get; set; } = string.Empty;
+}
+
+
 public class IssueCertificateOptions
 {
   [JsonPropertyName("subscriberName")]
@@ -505,6 +616,12 @@ class UpdateSecretResponse
   public Secret Secret { get; set; } = new Secret();
 }
 
+
+class CreateFolderResponse
+{
+  [JsonPropertyName("folder")]
+  public InfisicalFolder Folder { get; set; } = new InfisicalFolder();
+}
 class DeleteSecretResponse
 {
   [JsonPropertyName("secret")]

--- a/src/Infisical.Sdk/Model/Api.cs
+++ b/src/Infisical.Sdk/Model/Api.cs
@@ -379,17 +379,42 @@ public class CreateFolderOptions
 
 public class EnsureFolderPathOptions
 {
-  [JsonPropertyName("projectId")]
   public string? ProjectId { get; init; } = null;
 
-  [JsonPropertyName("environment")]
   public string? EnvironmentSlug { get; init; } = null;
 
-  [JsonPropertyName("path")]
   public string Path { get; init; } = "/";
 
-  [JsonPropertyName("description")]
   public string? Description { get; init; } = null;
+
+  internal void Validate()
+  {
+    if (string.IsNullOrEmpty(ProjectId))
+    {
+      throw new InfisicalException("ProjectId is required");
+    }
+
+    if (string.IsNullOrEmpty(EnvironmentSlug))
+    {
+      throw new InfisicalException("EnvironmentSlug is required");
+    }
+
+    if (string.IsNullOrEmpty(Path))
+    {
+      throw new InfisicalException("Path is required");
+    }
+  }
+}
+
+public class ListFoldersOptions
+{
+  public string? ProjectId { get; init; } = null;
+
+  public string? EnvironmentSlug { get; init; } = null;
+
+  public string Path { get; init; } = "/";
+
+  public bool Recursive { get; init; } = false;
 
   internal void Validate()
   {
@@ -444,6 +469,9 @@ public class InfisicalFolder
 
   [JsonPropertyName("path")]
   public string Path { get; set; } = string.Empty;
+
+  [JsonPropertyName("relativePath")]
+  public string RelativePath { get; set; } = string.Empty;
 }
 
 
@@ -616,6 +644,24 @@ class UpdateSecretResponse
   public Secret Secret { get; set; } = new Secret();
 }
 
+
+class ListFoldersResponse
+{
+  [JsonPropertyName("folders")]
+  public InfisicalFolder[] Folders { get; set; } = Array.Empty<InfisicalFolder>();
+}
+
+class FolderApiError
+{
+  [JsonPropertyName("statusCode")]
+  public int? StatusCode { get; set; }
+
+  [JsonPropertyName("error")]
+  public string? Error { get; set; }
+
+  [JsonPropertyName("message")]
+  public string? Message { get; set; }
+}
 
 class CreateFolderResponse
 {


### PR DESCRIPTION
Fixes #17.

## Why
.NET consumers can create/list/update/delete secrets at a `SecretPath`, but cannot provision folders through the SDK. `CreateSecret` fails when the target folder path does not already exist, forcing downstream apps to duplicate Universal Auth and call raw `POST /api/v2/folders`.

## What changed
- Adds `InfisicalClient.Folders()` and `FoldersClient`.
- Adds `CreateFolderOptions`, `EnsureFolderPathOptions`, and `InfisicalFolder` models.
- Adds `EnsurePathAsync(...)` to create nested folder segments in order and tolerate already-existing folder responses for race-safe provisioning.
- Adds an internal status-preserving POST helper used by folder provisioning while preserving existing public `PostAsync(...)` behavior.
- Updates the sample app to ensure a throwaway folder path before creating a secret.

## Verification
- `dotnet build infisical-dotnet-sdk.sln`